### PR TITLE
Use NSWindowController.windowFrameAutosaveName and don't steal focus

### DIFF
--- a/Sources/Preferences/PreferencesWindowController.swift
+++ b/Sources/Preferences/PreferencesWindowController.swift
@@ -29,7 +29,8 @@ public final class PreferencesWindowController: NSWindowController {
 		preferencePanes: [PreferencePane],
 		style: Preferences.Style = .toolbarItems,
 		animated: Bool = true,
-		hidesToolbarForSingleItem: Bool = true
+		hidesToolbarForSingleItem: Bool = true,
+		windowFrameAutosaveName: NSWindow.FrameAutosaveName? = nil
 	) {
 		precondition(!preferencePanes.isEmpty, "You need to set at least one view controller")
 
@@ -49,7 +50,7 @@ public final class PreferencesWindowController: NSWindowController {
 		self.hidesToolbarForSingleItem = hidesToolbarForSingleItem
 		super.init(window: window)
 
-		self.windowFrameAutosaveName = .preferences
+		self.windowFrameAutosaveName = windowFrameAutosaveName ?? .preferences
 
 		window.contentViewController = tabViewController
 
@@ -143,7 +144,8 @@ extension PreferencesWindowController {
 		panes: [PreferencePaneConvertible],
 		style: Preferences.Style = .toolbarItems,
 		animated: Bool = true,
-		hidesToolbarForSingleItem: Bool = true
+		hidesToolbarForSingleItem: Bool = true,
+		windowFrameAutosaveName: NSWindow.FrameAutosaveName? = nil
 	) {
 		let preferencePanes = panes.map { $0.asPreferencePane() }
 
@@ -151,7 +153,8 @@ extension PreferencesWindowController {
 			preferencePanes: preferencePanes,
 			style: style,
 			animated: animated,
-			hidesToolbarForSingleItem: hidesToolbarForSingleItem
+			hidesToolbarForSingleItem: hidesToolbarForSingleItem,
+			windowFrameAutosaveName: windowFrameAutosaveName
 		)
 	}
 }


### PR DESCRIPTION
This PR proposes a couple of changes: 

- Wraps the call to `NSApp.activate(ignoringOtherApps: true)` in a false-by-default boolean check. I know that this call is necessary for status bar/LSUIElement apps, but it's terribly poor form to use it elsewhere. Prior to this change, there is also no way to switch panes using the provided API without stealing focus.
- Replaces the calls to `setFrameUsingName(…)` and `setFrameAutosaveName(…)` in favour of `NSWindowController.windowFrameAutosaveName` which can be reset to a locally defined frame name after init. 
- Replaces the custom window placing code with a call to `NSWindow.center()` before we set the autosaved frame name. This has the effect of making the window appear in the centre of the display by default, but respecting the user's placement thereafter.

The only thing I need to resolve is setting a default location 