### PR TITLE
use nswindow.center() to center window

### DIFF
--- a/Sources/Settings/SettingsWindowController.swift
+++ b/Sources/Settings/SettingsWindowController.swift
@@ -102,16 +102,12 @@ public final class SettingsWindowController: NSWindowController {
 
 	private func restoreWindowPosition() {
 		guard
-			let window,
-			let screenContainingWindow = window.screen
+			let window
 		else {
 			return
 		}
 
-		window.setFrameOrigin(CGPoint(
-			x: screenContainingWindow.visibleFrame.midX - window.frame.width / 2,
-			y: screenContainingWindow.visibleFrame.midY - window.frame.height / 2
-		))
+		window.center()
 		window.setFrameUsingName(.settings)
 		window.setFrameAutosaveName(.settings)
 	}


### PR DESCRIPTION
Sets the window’s location to the center of the screen. The window is placed exactly in the center horizontally and somewhat above center vertically.