### PR TITLE
Suppressing warnings given by Xcode 15.

### DIFF
--- a/Sources/Settings/SettingsPane.swift
+++ b/Sources/Settings/SettingsPane.swift
@@ -1,4 +1,4 @@
-import Cocoa
+import AppKit
 
 extension Settings {
 	public struct PaneIdentifier: Hashable, RawRepresentable, Codable {

--- a/Sources/Settings/SettingsWindowController.swift
+++ b/Sources/Settings/SettingsWindowController.swift
@@ -98,7 +98,7 @@ public final class SettingsWindowController: NSWindowController {
 		showWindow(self)
 		restoreWindowPosition()
 		#if compiler(>=5.9) && canImport(AppKit)
-		if #available(macOS 14.0, *) {
+		if #available(macOS 14, *) {
 			NSApp.activate()
 		} else {
 			NSApp.activate(ignoringOtherApps: true)

--- a/Sources/Settings/SettingsWindowController.swift
+++ b/Sources/Settings/SettingsWindowController.swift
@@ -1,4 +1,4 @@
-import Cocoa
+import AppKit
 
 extension NSWindow.FrameAutosaveName {
 	static let settings: NSWindow.FrameAutosaveName = "com.sindresorhus.Settings.FrameAutosaveName"
@@ -97,7 +97,15 @@ public final class SettingsWindowController: NSWindowController {
 
 		showWindow(self)
 		restoreWindowPosition()
-		NSApp.activate(ignoringOtherApps: true)
+		#if canImport(AppKit, _version: "14.0")
+		if #available(macOS 14.0, *) {
+			NSApp.activate()
+		} else {
+			NSApp.activate(ignoringOtherApps: true)
+		}
+		#else
+			NSApp.activate(ignoringOtherApps: true)
+		#endif
 	}
 
 	private func restoreWindowPosition() {

--- a/Sources/Settings/SettingsWindowController.swift
+++ b/Sources/Settings/SettingsWindowController.swift
@@ -97,7 +97,7 @@ public final class SettingsWindowController: NSWindowController {
 
 		showWindow(self)
 		restoreWindowPosition()
-		#if canImport(AppKit, _version: "14.0")
+		#if compiler(>=5.9) && canImport(AppKit, _version: "14.0")
 		if #available(macOS 14.0, *) {
 			NSApp.activate()
 		} else {

--- a/Sources/Settings/SettingsWindowController.swift
+++ b/Sources/Settings/SettingsWindowController.swift
@@ -104,7 +104,7 @@ public final class SettingsWindowController: NSWindowController {
 			NSApp.activate(ignoringOtherApps: true)
 		}
 		#else
-			NSApp.activate(ignoringOtherApps: true)
+		NSApp.activate(ignoringOtherApps: true)
 		#endif
 	}
 

--- a/Sources/Settings/SettingsWindowController.swift
+++ b/Sources/Settings/SettingsWindowController.swift
@@ -97,7 +97,7 @@ public final class SettingsWindowController: NSWindowController {
 
 		showWindow(self)
 		restoreWindowPosition()
-		#if compiler(>=5.9) && canImport(AppKit, _version: "14.0")
+		#if compiler(>=5.9) && canImport(AppKit)
 		if #available(macOS 14.0, *) {
 			NSApp.activate()
 		} else {


### PR DESCRIPTION
* All `import Cocoa` are expected to be changed to `import AppKit` or `import UIKit` in order to be more platform-specific. Otherwise, Xcode 15 will give warnings.
* Use `NSApp.activate()` for macOS 14 Sonoma and later.

closing #102