### PR TITLE
Removing vChewing IME from README.md.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -339,7 +339,6 @@ You might also like Sindre's [apps](https://sindresorhus.com/apps).
 - [The Archive](https://zettelkasten.de/the-archive/) - Note-taking app by [Christian Tietze](https://github.com/DivineDominion)
 - [Word Counter](https://wordcounterapp.com) - Measuring writer's productivity by [Christian Tietze](https://github.com/DivineDominion)
 - [Medis](https://getmedis.com) - A Redis GUI by [Zihua Li](https://github.com/luin)
-- [vChewing IME](https://github.com/vChewing/vChewing-macOS) - Next-generation bopomofo-phonetic Chinese input method by [The vChewing Project](https://github.com/vChewing)
 
 Want to tell the world about your app that is using this package? Open a PR!
 


### PR DESCRIPTION
Due to some code-management reasons, I am deprecating this package from vChewing, considering that the APIs available in macOS 13 are already enough for this small input method project.

Still, I want to say thanks to this package and its contributors and maintainers.
This package helped vChewing in creating its preferences pane efficiently in the last year.

P.S.: This change will roll in since vChewing 3.6.0 update.
