### PR TITLE
Fix NSToolbar preserving the visual state of previous selected pane on macOS Sonoma

### DIFF
--- a/Sources/Settings/SettingsTabViewController.swift
+++ b/Sources/Settings/SettingsTabViewController.swift
@@ -144,6 +144,10 @@ final class SettingsTabViewController: NSViewController, SettingsStyleController
 			to: toViewController,
 			options: options
 		) { [self] in
+			if isAnimated,
+				 let toolbarItemStyleViewController = settingsStyleController as? ToolbarItemStyleViewController {
+				toolbarItemStyleViewController.refreshPreviousSelectedItem()
+			}
 			activeChildViewConstraints = toViewController.view.constrainToSuperviewBounds()
 		}
 	}

--- a/Sources/Settings/SettingsTabViewController.swift
+++ b/Sources/Settings/SettingsTabViewController.swift
@@ -144,10 +144,13 @@ final class SettingsTabViewController: NSViewController, SettingsStyleController
 			to: toViewController,
 			options: options
 		) { [self] in
-			if isAnimated,
-				 let toolbarItemStyleViewController = settingsStyleController as? ToolbarItemStyleViewController {
+			if
+		   		isAnimated,
+		   		let toolbarItemStyleViewController = settingsStyleController as? ToolbarItemStyleViewController
+		   	{
 				toolbarItemStyleViewController.refreshPreviousSelectedItem()
 			}
+
 			activeChildViewConstraints = toViewController.view.constrainToSuperviewBounds()
 		}
 	}

--- a/Sources/Settings/ToolbarItemStyleViewController.swift
+++ b/Sources/Settings/ToolbarItemStyleViewController.swift
@@ -53,8 +53,13 @@ final class ToolbarItemStyleViewController: NSObject, SettingsStyleController {
 	}
 
 	func selectTab(index: Int) {
+		toolbar.selectedItemIdentifier = panes[index].toolbarItemIdentifier
+	}
+  
+	public func refreshPreviousSelectedItem() {
 		// On macOS Sonoma, sometimes NSToolbar would preserve the
-		// visual selected state of previous selected toolbar item.
+		// visual selected state of previous selected toolbar item during
+		// view animation.
 		// AppKit doesn’t seem to offer a way to refresh toolbar items.
 		// So we manually “refresh” it.
 		if #available(macOS 14, *),
@@ -63,8 +68,6 @@ final class ToolbarItemStyleViewController: NSObject, SettingsStyleController {
 			toolbar.removeItem(at: index)
 			toolbar.insertItem(withItemIdentifier: previousSelected, at: index)
 		}
-		
-		toolbar.selectedItemIdentifier = panes[index].toolbarItemIdentifier
 		previousSelectedItemIdentifier = toolbar.selectedItemIdentifier
 	}
 }

--- a/Sources/Settings/ToolbarItemStyleViewController.swift
+++ b/Sources/Settings/ToolbarItemStyleViewController.swift
@@ -62,12 +62,15 @@ final class ToolbarItemStyleViewController: NSObject, SettingsStyleController {
 		// view animation.
 		// AppKit doesn’t seem to offer a way to refresh toolbar items.
 		// So we manually “refresh” it.
-		if #available(macOS 14, *),
-			 let previousSelected = previousSelectedItemIdentifier,
-			 let index = toolbar.items.firstIndex(where: { $0.itemIdentifier == previousSelected }) {
+		if
+			#available(macOS 14, *),
+			let previousSelectedItemIdentifier,
+			let index = toolbar.items.firstIndex(where: { $0.itemIdentifier == previousSelectedItemIdentifier })
+		{
 			toolbar.removeItem(at: index)
 			toolbar.insertItem(withItemIdentifier: previousSelected, at: index)
 		}
+
 		previousSelectedItemIdentifier = toolbar.selectedItemIdentifier
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -339,6 +339,7 @@ You might also like Sindre's [apps](https://sindresorhus.com/apps).
 - [The Archive](https://zettelkasten.de/the-archive/) - Note-taking app by [Christian Tietze](https://github.com/DivineDominion)
 - [Word Counter](https://wordcounterapp.com) - Measuring writer's productivity by [Christian Tietze](https://github.com/DivineDominion)
 - [Medis](https://getmedis.com) - A Redis GUI by [Zihua Li](https://github.com/luin)
+- [OK JSON](https://okjson.app) - A scriptable JSON formatter by [Francis Feng](https://github.com/francisfeng)
 
 Want to tell the world about your app that is using this package? Open a PR!
 


### PR DESCRIPTION
![Example](https://github.com/sindresorhus/Settings/assets/1040288/c025cb47-bcf7-49da-b68c-8bfe82b6af54)

As shown in the screenshot, there’s a UI glitch on Sonoma 14.0. It can be easily reproduced by simply running the Example project and switching around the setting panes.

You won’t have this issue if you set `animate` to `false` during the initialization of `SettingsWindowController`.

Apple may fix this issue in a future release of Sonoma, which makes this workaround useless. But I don’t know if we should wait or not.