### PR TITLE
Update namespace from Settings to AppSettings

### DIFF
--- a/Sources/Settings/Settings.swift
+++ b/Sources/Settings/Settings.swift
@@ -4,13 +4,14 @@ The namespace for this package.
 public enum Settings {}
 
 /**
-A typealias for this package's namespace to solve the conflict with [SwiftUI.Settings](https://developer.apple.com/documentation/swiftui/settings)
+A typealias for this package's namespace to solve the conflict with [SwiftUI.Settings](https://developer.apple.com/documentation/swiftui/settings).
 
-You can also use the following code snippet to solve the conflict
+You can also use the following code snippet to solve the conflict:
+
 ```swift
 import enum Settings.Settings
 ```
- */
+*/
 public typealias AppSettings = Settings
 
 // TODO: Remove in the next major version.

--- a/Sources/Settings/Settings.swift
+++ b/Sources/Settings/Settings.swift
@@ -3,12 +3,14 @@ The namespace for this package.
 */
 public enum Settings {}
 
-/// A typealias for this package's namespace to solve the conflict with [SwiftUI.Settings](https://developer.apple.com/documentation/swiftui/settings)
-///
-/// You can also use the following code snippet to solve the conflict
-/// ```swift
-/// import enum Settings.Settings
-/// ```
+/**
+A typealias for this package's namespace to solve the conflict with [SwiftUI.Settings](https://developer.apple.com/documentation/swiftui/settings)
+
+You can also use the following code snippet to solve the conflict
+```swift
+import enum Settings.Settings
+```
+ */
 public typealias AppSettings = Settings
 
 // TODO: Remove in the next major version.

--- a/Sources/Settings/Settings.swift
+++ b/Sources/Settings/Settings.swift
@@ -3,7 +3,7 @@ The namespace for this package.
 */
 public enum Settings {}
 
-/// A typealias for this package's namespace to solve the conflict with SwiftUI.Settings
+/// A typealias for this package's namespace to solve the conflict with [SwiftUI.Settings](https://developer.apple.com/documentation/swiftui/settings)
 ///
 /// You can also use the following code snippet to solve the conflict
 /// ```swift

--- a/Sources/Settings/Settings.swift
+++ b/Sources/Settings/Settings.swift
@@ -3,6 +3,14 @@ The namespace for this package.
 */
 public enum Settings {}
 
+/// A typealias for this package's namespace to solve the conflict with SwiftUI.Settings
+///
+/// You can also use the following code snippet to solve the conflict
+/// ```swift
+/// import enum Settings.Settings
+/// ```
+public typealias AppSettings = Settings
+
 // TODO: Remove in the next major version.
 // Preserve backwards compatibility.
 @available(*, deprecated, renamed: "Settings")


### PR DESCRIPTION
Fix conflict when using `import SwiftUI` and `import Settings`.
Before the commit, downstream users can use `import enum Settings.Settings` to workaround.

Fix #110
Closes #111 