### PR TITLE
horizontally align SwiftUI Pane to the center like Safari Settings does. Fixes sindresorhus/Settings#106

### DIFF
--- a/Sources/Settings/Container.swift
+++ b/Sources/Settings/Container.swift
@@ -50,7 +50,7 @@ extension Settings {
 				}
 			}
 			.modifier(Section.LabelWidthModifier(maximumWidth: $maximumLabelWidth))
-			.frame(width: contentWidth, alignment: .leading)
+			.frame(width: contentWidth, alignment: .center)
 			.padding(.vertical, 20)
 			.padding(.horizontal, 30)
 		}

--- a/Sources/Settings/Section.swift
+++ b/Sources/Settings/Section.swift
@@ -114,7 +114,6 @@ extension Settings {
 				label
 					.alignmentGuide(.settingsSectionLabel) { $0[.trailing] }
 				content
-				Spacer()
 			}
 		}
 	}


### PR DESCRIPTION
Fixes sindresorhus/Settings#106

After: 
![截屏2024-05-30 17 45 14](https://github.com/sindresorhus/Settings/assets/1069839/fca847fe-2365-47fe-bb25-0c3652457952)

Before:
![截屏2024-05-30 17 44 35](https://github.com/sindresorhus/Settings/assets/1069839/c48e8711-2ca9-411e-a66d-e3bbccb21671)
