### PR TITLE
Fix segmented control style showing duplicate labels

### DIFF
--- a/Sources/Settings/SettingsTabViewController.swift
+++ b/Sources/Settings/SettingsTabViewController.swift
@@ -36,7 +36,7 @@ final class SettingsTabViewController: NSViewController, SettingsStyleController
 
 		let toolbar = NSToolbar(identifier: "SettingsToolbar")
 		toolbar.allowsUserCustomization = false
-		toolbar.displayMode = .iconAndLabel
+		toolbar.displayMode = style == .segmentedControl ? .iconOnly : .iconAndLabel
 		toolbar.showsBaselineSeparator = true
 		toolbar.delegate = self
 


### PR DESCRIPTION
Set toolbar displayMode to .iconOnly for segmented control style to prevent showing redundant labels below the segmented control, which already contains the pane titles.